### PR TITLE
feat: Add Craft CMS 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ return static function(ECSConfig $ecsConfig): void {
 
     $ecsConfig->sets([SetList::CRAFT_CMS_3]); // for Craft 3 projects
     $ecsConfig->sets([SetList::CRAFT_CMS_4]); // for Craft 4 projects
+    $ecsConfig->sets([SetList::CRAFT_CMS_5]); // for Craft 5 projects
 };
 ```
 
 Adjust the `PATHS` value to include all source/test code locations, and remove the appropriate `SetList` option,
-depending on whether this is for Craft 3 or Craft 4.
+depending on whether this is for Craft 3, Craft 4, or Craft CMS 5.
 
 With that in place, you can check your plugin/project’s code with the following command:
 

--- a/sets/craft-cms-5.php
+++ b/sets/craft-cms-5.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return static function(ECSConfig $ecsConfig): void {
+    $ecsConfig->import(__DIR__ . '/craft-cms-4.php');
+};

--- a/src/SetList.php
+++ b/src/SetList.php
@@ -8,4 +8,5 @@ final class SetList
 {
     public const CRAFT_CMS_3 = __DIR__ . '/../sets/craft-cms-3.php';
     public const CRAFT_CMS_4 = __DIR__ . '/../sets/craft-cms-4.php';
+    public const CRAFT_CMS_5 = __DIR__ . '/../sets/craft-cms-5.php';
 }


### PR DESCRIPTION
### Description

Adds `SetList::CRAFT_CMS_5` constants for Craft CMS 5 support

Yes, it's just an empty config that inherits from Craft CMS 4's config... but it feels right... and the addition in the docs gives people the confirmation that yes, this is updated and you can and should use it with Craft CMS 5.

### Related issues

